### PR TITLE
Fix GHC & Stack warnings across the codebase

### DIFF
--- a/strato/VM/SolidVM/solid-vm-model/package.yaml
+++ b/strato/VM/SolidVM/solid-vm-model/package.yaml
@@ -10,7 +10,7 @@ default-extensions:
 library:
   source-dirs: src/
   dependencies:
-  - aeson ==2.1.1.0
+  - aeson >=2.1.1.0 && <2.3
   - aeson-casing
   - attoparsec
   - base16-bytestring

--- a/strato/libs/json-rpc-server/json-rpc-server.cabal
+++ b/strato/libs/json-rpc-server/json-rpc-server.cabal
@@ -8,7 +8,7 @@ maintainer:          Kristen Kozak <grayjay@wordroute.com>
 synopsis:            JSON-RPC 2.0 on the server side.
 build-type:          Simple
 extra-source-files:  changelog.md
-cabal-version:       >=1.8
+cabal-version:       >=1.10
 tested-with:         GHC == 7.0.1, GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.1,
                      GHC == 7.10.2, GHC == 7.10.3, GHC == 8.0.1, GHC == 8.0.2,
                      GHC == 8.2.2, GHC == 8.4.1, GHC == 8.4.4, GHC == 8.6.1,

--- a/strato/libs/kafka/milena/package.yaml
+++ b/strato/libs/kafka/milena/package.yaml
@@ -46,19 +46,19 @@ library:
 
   dependencies:
     - base >=4.7 && <5
-    - bytestring >=0.10 && <0.11
+    - bytestring >=0.10 && <0.12
     - cereal >=0.4 && <0.6
     - containers >=0.5 && <0.7
     - digest >=0.0.1.0 && <0.1
-    - lens >=4.4 && <4.20
+    - lens >=4.4 && <6.0
     - lifted-base >=0.2.3.6 && <0.3
     - monad-control >=1.0 && <1.1
-    - mtl >=2.1 && <2.3
+    - mtl >=2.1 && <2.4
     - murmur-hash >=0.1.0.8 && <0.2
     - network 
-    - random >=1.0 && <1.2
-    - resource-pool >=0.2.3.2 && <0.3
-    - transformers >=0.3 && <0.6
+    - random >=1.0 && <1.3
+    - resource-pool >=0.2.3.2 && <0.5
+    - transformers >=0.3 && <0.7
     - zlib >=0.6.1.2 && <0.7
 
 tests:

--- a/strato/libs/type-lits/package.yaml
+++ b/strato/libs/type-lits/package.yaml
@@ -4,7 +4,7 @@ library:
   source-dirs: src
   dependencies:
     - base
-    - aeson ==2.1.1.0
+    - aeson >=2.1.1.0 && <2.3
     - bifunctors
     - comonad
     - QuickCheck

--- a/strato/stack.yaml
+++ b/strato/stack.yaml
@@ -130,6 +130,8 @@ nix:
   # See https://docs.haskellstack.org/en/stable/nix_integration/#using-a-custom-shellnix-file
   shell-file: nix/stack-integration.nix
 
+notify-if-nix-on-path: false
+
 resolver: lts-22.4 #also duplicated in docker section below
 compiler-check: newer-minor
 extra-include-dirs:


### PR DESCRIPTION
  ## Summary
  
  - Updated cabal-version requirement in json-rpc-server from 1.8 to 1.10 to support other-extensions field
  - Relaxed outdated dependency bounds in `milena`, `type-lits`, and `solid-vm-model` packages
  - Eliminated Stack's allow-newer warnings by updating bounds to match LTS resolver versions
  - Eliminated nix on path warning

  ## Motivation
  
  While these changes are trivial from a functionality perspective, maintaining warning-free compiler output provides significant benefits:

  - **Improved signal-to-noise ratio**: Real issues don't get buried in routine warnings
  - **Faster development cycles**: Developers can quickly spot actual problems without scanning through known warnings
  - **Better CI/CD reliability**: Automated builds can treat warnings as errors without false positives
  - **Professional polish**: Clean build output reflects well-maintained code and attention to detail
  - **Easier debugging**: When something does go wrong, the relevant messages stand out clearly

## Changes

### Upgrade cabal-version to >=1.10

When building the project, compiler printed warninging about field
'other-extensions' not being specified in the current cabal version

  The cabal-version specifies the minimum version of the Cabal specification
  that the .cabal file uses. Here's what you need to know:

  The cabal-version field tells Cabal which features and syntax are available in
  that .cabal file. Different Cabal versions introduced different features:

  - 1.8: Basic functionality
  - 1.10: Introduced other-extensions, default-extensions, and other fields

  1. We only bumped from 1.8 → 1.10: This is a very conservative change. Cabal
  1.10 was released in 2011, so any modern toolchain supports it.

  2. The file was already using 1.10+ features: The other-extensions field
  requires Cabal 1.10+, so the file was effectively broken with cabal-version:
  >=1.8. We just made the declaration match reality.

  3. Stack already requires modern Cabal: The project uses Stack, which bundles
  a modern version of Cabal internally.

  Very low risk because:

  - Cabal 1.10 is 13+ years old - any system building this code already has it
  - The change only affects the build metadata, not the actual Haskell code
  - We didn't add new features, just fixed a version mismatch
  - Other .cabal files in the project already use 1.10+ or 1.12

  The only theoretical risk would be someone using an extremely old Cabal from
  before 2011, which is essentially impossible in any practical modern Haskell
  development environment.


### Update dependency bounds to remove the "ignoring bounds" warnings

 The warnings occurred because:
  - allow-newer: true in stack.yaml lets Stack ignore overly restrictive dependency bounds
  - Stack was using newer versions than packages declared they supported:
    - milena declared transformers <0.6 but Stack used 0.6.1.0
    - milena declared mtl <2.3 but Stack used 2.3.1
    - type-lits and solid-vm-model pinned aeson ==2.1.1.0 but Stack used 2.1.2.1

  1. Conservative updates: I only relaxed upper bounds to accommodate versions already in use
  2. Semantic versioning: Minor version bumps (like 2.1.1.0 → 2.1.2.1) shouldn't break APIs
  3. Active testing: The project already builds and runs with these newer versions via allow-newer

### Disable warning when nix on PATH


Currently the stack configuration explicitly disables nix integration. However
Stack is configured in such a way, that when nix integration is disabled but nix
executable is available on the PATH, the stack will issue a warning each time it
is being called.

The `notify-if-nix-on-path: false` disables this.

Fun fact, stack recognizes if user is using NixOS Linux distribution and
disables this warning for NixOS users

Yes.

Users without nix will not see the difference.
Users with nix will no longer see the warning.
Users on NixOS will not see any difference.